### PR TITLE
Issue 17 add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,87 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+venv/
+env/
+.venv/
+.ENV/
+ENV/
+
+# Flask instance folder (contains config, uploads, etc.)
+instance/
+
+# Flask cache and logs
+*.log
+*.pid
+
+# Jinja2 cache
+*.jinja2c
+
+# Static files (compiled assets, optional)
+static/build/
+static/dist/
+static/*.tmp
+static/*.map
+
+# Node.js dependencies (if using npm/yarn for Bootstrap/JS)
+node_modules/
+package-lock.json
+yarn.lock
+
+# Compiled CSS/JS (optional if you're building assets from SCSS/JS)
+*.min.js
+*.min.css
+
+# Coverage, test, and temp files
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.pytest_cache/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Editor settings
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# OS-specific
+.DS_Store
+Thumbs.db
+
+# Database
+*.sqlite3
+*.db
+
+# Environment variables
+.env
+.env.*
+
+# Build / dist files
+build/
+dist/
+*.egg-info/
+.eggs/
+develop-eggs/
+downloads/
+parts/
+sdist/
+*.egg
+.installed.cfg
+
+# Misc
+*.bak
+*.swp
+*.tmp


### PR DESCRIPTION
**Description:**

This pull request adds a `.gitignore` file to the project to prevent unnecessary files and folders from being tracked by Git. It covers common exclusions for a Flask-based web application that uses Jinja2 templates, Bootstrap, JavaScript, and jQuery.

**Key additions to `.gitignore`:**
- Python cache files: `__pycache__/`, `*.pyc`
- Virtual environments: `venv/`, `.venv/`, `env/`
- Flask-specific folders: `instance/`, `*.log`
- Environment files: `.env`, `.env.*`
- Static asset builds and maps: `*.min.js`, `*.min.css`, `*.map`, `static/build/`
- Node-related files: `node_modules/`, `package-lock.json`, `yarn.lock`
- Editor/IDE configs: `.vscode/`, `.idea/`
- OS-specific files: `.DS_Store`, `Thumbs.db`
- Test and coverage files: `.coverage`, `.pytest_cache/`, etc.
